### PR TITLE
Adapt to changes to GHC's internals so that the plugin compiles again…

### DIFF
--- a/src/TypeNatSolver.hs
+++ b/src/TypeNatSolver.hs
@@ -926,10 +926,17 @@ varToType x vi = go (smtCurScope vi : smtOtherScopes vi)
 
 -- | Pick an SMT name for a Haskell type variable.
 thyVarName :: TyVar -> String
-thyVarName x = occNameString (nameOccName n) ++ "_" ++ show u
+thyVarName x = encodeString (occNameString (nameOccName n)) ++ "_" ++ show u
   where n = tyVarName x
         u = nameUnique n
-
+        -- We need to encode strings because the SMTLib format
+        -- does not like apostrophes, yet Haskell programmers do.
+        -- We replace apostrophes with hyphens, because hyphens
+        -- are not valid in type variable names in Haskell.
+        encodeString =
+          map $ \c -> case c of
+            '\'' -> '-'
+            x   -> x
 
 
 

--- a/type-nat-solver.cabal
+++ b/type-nat-solver.cabal
@@ -11,7 +11,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     TypeNatSolver
-  build-depends:       base, containers, ghc, simple-smt >= 0.5.4
+  build-depends:       base, containers, ghc, simple-smt >= 0.5.4, ghc-tcplugins-extra >= 0.1
   default-language:    Haskell2010
   GHC-options:         -Wall -O2
 


### PR DESCRIPTION
```
Adapt to changes to GHC's internals so that the plugin compiles against HEAD

This fixes issue #4.

Pulling in the shim package ghc-tcplugins-extra allows us to easily have
forward and backward compatibility. There is more here that could potentially
be adapted to rely on ghc-tcplugins-extra, but for now, only altering the
definition of `mkNewFact` is necessary to regain compatibility with HEAD
(and retain compatibility with 7.10).

These changes alter `mkNewFact' to be monadic (in TcPluginM), because the new
infrastructure uses EvVars to hold evidence, and generating a new EvVar requires
performing actions in TcPluginM.
```
